### PR TITLE
Add more adverserial checks and tests

### DIFF
--- a/.github/workflows/anchor-test.yaml
+++ b/.github/workflows/anchor-test.yaml
@@ -6,3 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: metadaobuilders/anchor-test@v1
+        with:
+          - anchor-version: '0.25.0'
+            solana-cli-version: '1.14.3'

--- a/.github/workflows/anchor-test.yaml
+++ b/.github/workflows/anchor-test.yaml
@@ -1,5 +1,10 @@
 name: anchor-test
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   run-anchor-test:
     runs-on: ubuntu-20.04
@@ -7,5 +12,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: metadaobuilders/anchor-test@v1
         with:
-          - anchor-version: '0.25.0'
+            anchor-version: '0.25.0'
             solana-cli-version: '1.14.3'

--- a/.github/workflows/anchor-test.yaml
+++ b/.github/workflows/anchor-test.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: metadaobuilders/anchor-test@v1
         with:
-            anchor-version: '0.25.0'
+            anchor-version: '0.24.2'
             solana-cli-version: '1.14.3'

--- a/tests/accountInitializationUtils.ts
+++ b/tests/accountInitializationUtils.ts
@@ -1,0 +1,184 @@
+import * as anchor from "@project-serum/anchor";
+import { expect, assert } from "chai";
+import * as pdaGenUtils from "./pdaGenerationUtils";
+import * as token from "@solana/spl-token";
+import { Program } from "@project-serum/anchor";
+import { ConditionalVault } from "../target/types/conditional_vault";
+
+export async function initializeConditionalExpression(
+  program: Program,
+  proposalNumber: number,
+  redeemableOnPass: boolean
+) {
+  const conditionalExpressionAccount =
+    await pdaGenUtils.generateConditionalExpressionPDAAddress(
+      program,
+      proposalNumber,
+      redeemableOnPass
+    );
+
+  await program.methods
+    .initializeConditionalExpression(
+      new anchor.BN(proposalNumber),
+      redeemableOnPass
+    )
+    .accounts({
+      conditionalExpression: conditionalExpressionAccount,
+      initializer: program.provider.wallet.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .rpc();
+
+  const storedConditionalExpression =
+    await program.account.conditionalExpression.fetch(
+      conditionalExpressionAccount
+    );
+
+  assert.ok(
+    storedConditionalExpression.proposalNumber.eq(new anchor.BN(proposalNumber))
+  );
+  assert.equal(storedConditionalExpression.passOrFailFlag, redeemableOnPass);
+
+  // console.log("Conditional expression successfully initialized.");
+
+  return conditionalExpressionAccount;
+}
+
+export const initializeUnderlyingTokenMint = async (
+  provider: anchor.Provider
+) => {
+  const underlyingTokenMintAuthority = anchor.web3.Keypair.generate();
+
+  const underlyingTokenMint = await token.createMint(
+    provider.connection,
+    provider.wallet.payer,
+    underlyingTokenMintAuthority.publicKey,
+    null,
+    2
+  );
+
+  return [underlyingTokenMint, underlyingTokenMintAuthority];
+};
+
+export const initializeConditionalVault = async (
+  program: Program,
+  conditionalExpression: anchor.web3.PublicKey,
+  underlyingTokenMint: anchor.web3.PublicKey
+) => {
+  const provider = program.provider;
+
+  const conditionalVault = await pdaGenUtils.generateConditionalVaultPDAAddress(
+    program,
+    conditionalExpression,
+    underlyingTokenMint
+  );
+
+  const conditionalTokenMint = await token.createMint(
+    provider.connection,
+    provider.wallet.payer,
+    conditionalVault, // mint authority
+    null,
+    2
+  );
+
+  const vaultUnderlyingTokenAccount = (
+    await token.getOrCreateAssociatedTokenAccount(
+      provider.connection,
+      provider.wallet.payer,
+      underlyingTokenMint,
+      conditionalVault,
+      true
+    )
+  ).address;
+
+  await program.methods
+    .initializeConditionalVault()
+    .accounts({
+      conditionalVault,
+      conditionalExpression,
+      underlyingTokenMint,
+      conditionalTokenMint: conditionalTokenMint,
+      vaultUnderlyingTokenAccount: vaultUnderlyingTokenAccount,
+      initializer: provider.wallet.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .rpc();
+
+  const storedConditionalVault = await program.account.conditionalVault.fetch(
+    conditionalVault
+  );
+
+  assert.ok(
+    storedConditionalVault.conditionalExpression.equals(conditionalExpression)
+  );
+  assert.ok(
+    storedConditionalVault.underlyingTokenAccount.equals(
+      vaultUnderlyingTokenAccount
+    )
+  );
+  assert.ok(
+    storedConditionalVault.underlyingTokenMint.equals(underlyingTokenMint)
+  );
+  assert.ok(
+    storedConditionalVault.conditionalTokenMint.equals(conditionalTokenMint)
+  );
+
+  console.log("Conditional vault successfully initialized.");
+
+  return [conditionalVault, conditionalTokenMint, vaultUnderlyingTokenAccount];
+};
+
+export const initializeDepositAccount = async (
+  program: Program,
+  conditionalVault: anchor.web3.PublicKey
+) => {
+  const provider = program.provider;
+
+  const depositAccount = await pdaGenUtils.generateDepositAccountPDAAddress(
+    program,
+    conditionalVault,
+    provider.wallet.publicKey // the provider's wallet will be the one minting
+  );
+
+  await program.methods
+    .initializeDepositAccount()
+    .accounts({
+      conditionalVault,
+      depositAccount,
+      depositor: provider.wallet.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .rpc();
+
+  let storedDepositAccount = await program.account.depositAccount.fetch(
+    depositAccount
+  );
+
+  assert.ok(storedDepositAccount.conditionalVault.equals(conditionalVault));
+  assert.ok(storedDepositAccount.depositor.equals(provider.wallet.publicKey));
+  assert.ok(storedDepositAccount.depositedAmount.eq(new anchor.BN(0)));
+
+  console.log("Deposit account successfully initialized.");
+
+  return depositAccount;
+};
+
+export const initializeProposalAccount = async (
+  program: Program<ConditionalVault>,
+  proposalNumber: number
+) => {
+  const provider = program.provider;
+  const proposalKeypair = anchor.web3.Keypair.generate();
+
+  await program.methods
+    .initializeProposal(new anchor.BN(proposalNumber))
+    .accounts({
+      proposal: proposalKeypair.publicKey,
+      initializer: provider.wallet.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .signers([proposalKeypair])
+    .rpc();
+
+  return proposalKeypair.publicKey;
+};

--- a/tests/accountInitializationUtils.ts
+++ b/tests/accountInitializationUtils.ts
@@ -7,25 +7,23 @@ import { ConditionalVault } from "../target/types/conditional_vault";
 
 export async function initializeConditionalExpression(
   program: Program,
-  proposalNumber: number,
+  proposal: anchor.web3.PublicKey,
   redeemableOnPass: boolean
 ) {
   const conditionalExpressionAccount =
     await pdaGenUtils.generateConditionalExpressionPDAAddress(
       program,
-      proposalNumber,
+      proposal,
       redeemableOnPass
     );
 
   await program.methods
-    .initializeConditionalExpression(
-      new anchor.BN(proposalNumber),
-      redeemableOnPass
-    )
+    .initializeConditionalExpression(redeemableOnPass)
     .accounts({
       conditionalExpression: conditionalExpressionAccount,
       initializer: program.provider.wallet.publicKey,
       systemProgram: anchor.web3.SystemProgram.programId,
+      proposal,
     })
     .rpc();
 
@@ -34,9 +32,7 @@ export async function initializeConditionalExpression(
       conditionalExpressionAccount
     );
 
-  assert.ok(
-    storedConditionalExpression.proposalNumber.eq(new anchor.BN(proposalNumber))
-  );
+  assert.ok(storedConditionalExpression.proposal.equals(proposal));
   assert.equal(storedConditionalExpression.passOrFailFlag, redeemableOnPass);
 
   // console.log("Conditional expression successfully initialized.");

--- a/tests/conditionalVault.ts
+++ b/tests/conditionalVault.ts
@@ -107,136 +107,30 @@ describe("Conditional vault", () => {
     const proposalNumber = 0;
     const redeemableOnPass = false;
 
-    const conditionalExpressionAccount =
-      await generateConditionalExpressionPDAAddress(
+    const conditionalExpression =
+      await accountInitUtils.initializeConditionalExpression(
         program,
         proposalNumber,
         redeemableOnPass
       );
 
-    await program.methods
-      .initializeConditionalExpression(
-        new anchor.BN(proposalNumber),
-        redeemableOnPass
-      )
-      .accounts({
-        conditionalExpression: conditionalExpressionAccount,
-        initializer: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc();
+    const [underlyingTokenMint, underlyingTokenMintAuthority] =
+      await accountInitUtils.initializeUnderlyingTokenMint(provider);
 
-    const storedConditionalExpression =
-      await program.account.conditionalExpression.fetch(
-        conditionalExpressionAccount
-      );
-
-    assert.ok(
-      storedConditionalExpression.proposalNumber.eq(
-        new anchor.BN(proposalNumber)
-      )
-    );
-    assert.equal(storedConditionalExpression.passOrFailFlag, redeemableOnPass);
-
-    console.log("Conditional expression successfully initialized.");
-
-    const underlyingTokenMintAuthority = anchor.web3.Keypair.generate();
-
-    const underlyingTokenMint = await token.createMint(
-      provider.connection,
-      provider.wallet.payer,
-      underlyingTokenMintAuthority.publicKey,
-      null,
-      2
-    );
-
-    const conditionalVaultAccount = await generateConditionalVaultPDAAddress(
+    const [
+      conditionalVault,
+      conditionalTokenMint,
+      vaultUnderlyingTokenAccount,
+    ] = await accountInitUtils.initializeConditionalVault(
       program,
-      conditionalExpressionAccount,
+      conditionalExpression,
       underlyingTokenMint
     );
 
-    const conditionalTokenMint = await token.createMint(
-      provider.connection,
-      provider.wallet.payer,
-      conditionalVaultAccount, // mint authority
-      null,
-      2
-    );
-
-    const vaultUnderlyingTokenAccount = (
-      await token.getOrCreateAssociatedTokenAccount(
-        provider.connection,
-        provider.wallet.payer,
-        underlyingTokenMint,
-        conditionalVaultAccount,
-        true
-      )
-    ).address;
-
-    await program.methods
-      .initializeConditionalVault()
-      .accounts({
-        conditionalVault: conditionalVaultAccount,
-        conditionalExpression: conditionalExpressionAccount,
-        underlyingTokenMint: underlyingTokenMint,
-        conditionalTokenMint: conditionalTokenMint,
-        vaultUnderlyingTokenAccount: vaultUnderlyingTokenAccount,
-        initializer: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc();
-
-    const storedConditionalVault = await program.account.conditionalVault.fetch(
-      conditionalVaultAccount
-    );
-
-    assert.ok(
-      storedConditionalVault.conditionalExpression.equals(
-        conditionalExpressionAccount
-      )
-    );
-    assert.ok(
-      storedConditionalVault.underlyingTokenAccount.equals(
-        vaultUnderlyingTokenAccount
-      )
-    );
-    assert.ok(
-      storedConditionalVault.underlyingTokenMint.equals(underlyingTokenMint)
-    );
-    assert.ok(
-      storedConditionalVault.conditionalTokenMint.equals(conditionalTokenMint)
-    );
-
-    console.log("Conditional vault successfully initialized.");
-
-    const depositAccount = await generateDepositAccountPDAAddress(
+    const depositAccount = await accountInitUtils.initializeDepositAccount(
       program,
-      conditionalVaultAccount,
-      provider.wallet.publicKey // the provider's wallet will be the one minting
+      conditionalVault
     );
-
-    await program.methods
-      .initializeDepositAccount()
-      .accounts({
-        conditionalVault: conditionalVaultAccount,
-        depositAccount,
-        depositor: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc();
-
-    let storedDepositAccount = await program.account.depositAccount.fetch(
-      depositAccount
-    );
-
-    assert.ok(
-      storedDepositAccount.conditionalVault.equals(conditionalVaultAccount)
-    );
-    assert.ok(storedDepositAccount.depositor.equals(provider.wallet.publicKey));
-    assert.ok(storedDepositAccount.depositedAmount.eq(new anchor.BN(0)));
-
-    console.log("Deposit account successfully initialized.");
 
     const userUnderlyingTokenAccount = await token.createAccount(
       provider.connection,
@@ -245,8 +139,8 @@ describe("Conditional vault", () => {
       provider.wallet.publicKey
     );
 
-    const underlyingAmountToMint = 15000;
-    const conditionalAmountToMint = 15000;
+    const underlyingAmountToMint = 1000;
+    const conditionalAmountToMint = 400;
 
     await token.mintTo(
       provider.connection,
@@ -264,111 +158,33 @@ describe("Conditional vault", () => {
       provider.wallet.publicKey
     );
 
+    await utils.mintConditionalTokens(
+      program,
+      conditionalVault,
+      conditionalAmountToMint,
+      depositAccount,
+      userUnderlyingTokenAccount,
+      userConditionalTokenAccount
+    );
+
+    const proposal = await accountInitUtils.initializeProposalAccount(
+      program,
+      proposalNumber
+    );
+
     await program.methods
-      .mintConditionalTokens(new anchor.BN(conditionalAmountToMint))
+      .passProposal()
       .accounts({
-        conditionalVault: conditionalVaultAccount,
-        tokenProgram: token.TOKEN_PROGRAM_ID,
-        conditionalTokenMint,
-        user: provider.wallet.publicKey,
-        depositAccount,
-        vaultUnderlyingTokenAccount,
-        userUnderlyingTokenAccount,
-        userConditionalTokenAccount,
+        proposal,
       })
       .rpc();
 
-    assert.equal(
-      (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
-        .amount,
-      underlyingAmountToMint - conditionalAmountToMint
+    await utils.redeemDepositAccountForUnderlyingTokens(
+      program,
+      depositAccount,
+      userUnderlyingTokenAccount,
+      conditionalVault,
+      proposal
     );
-    assert.equal(
-      (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
-        .amount,
-      conditionalAmountToMint
-    );
-    assert.equal(
-      (await token.getAccount(provider.connection, userConditionalTokenAccount))
-        .amount,
-      conditionalAmountToMint
-    );
-
-    storedDepositAccount = await program.account.depositAccount.fetch(
-      depositAccount
-    );
-
-    // these should remain the same
-    assert.ok(
-      storedDepositAccount.conditionalVault.equals(conditionalVaultAccount)
-    );
-    assert.ok(storedDepositAccount.depositor.equals(provider.wallet.publicKey));
-    // this should increase
-    assert.ok(
-      storedDepositAccount.depositedAmount.eq(
-        new anchor.BN(conditionalAmountToMint)
-      )
-    );
-
-    console.log(
-      "Conditional token account successfully credited after deposit."
-    );
-
-    const proposalAccount = anchor.web3.Keypair.generate();
-
-    await program.methods
-      .initializeProposal(new anchor.BN(proposalNumber))
-      .accounts({
-        proposal: proposalAccount.publicKey,
-        initializer: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .signers([proposalAccount])
-      .rpc();
-
-    await program.methods
-      .passProposal() // this invalidates the conditional tokens
-      .accounts({
-        proposal: proposalAccount.publicKey,
-      })
-      .rpc();
-
-    await program.methods
-      .redeemDepositAccountForUnderlyingTokens()
-      .accounts({
-        user: provider.wallet.publicKey,
-        userDepositAccount: depositAccount,
-        userUnderlyingTokenAccount,
-        vaultUnderlyingTokenAccount,
-        conditionalVault: conditionalVaultAccount,
-        proposal: proposalAccount.publicKey,
-        tokenProgram: token.TOKEN_PROGRAM_ID,
-        conditionalExpression: conditionalExpressionAccount,
-      })
-      .rpc();
-
-    assert.equal(
-      (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
-        .amount,
-      underlyingAmountToMint
-    );
-    assert.equal(
-      (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
-        .amount,
-      0
-    );
-    assert.equal(
-      (await token.getAccount(provider.connection, userConditionalTokenAccount))
-        .amount,
-      conditionalAmountToMint
-    ); // conditional token balance should remain the same - these tokens are now worthless
-
-    storedDepositAccount = await program.account.depositAccount.fetch(
-      depositAccount
-    );
-
-    assert.ok(storedDepositAccount.depositedAmount.eq(new anchor.BN(0)));
-
-    console.log("Underlying tokens successfully redeemed after proposal pass");
   });
 });

--- a/tests/conditionalVault.ts
+++ b/tests/conditionalVault.ts
@@ -292,11 +292,20 @@ describe("Conditional vault", () => {
       assert.fail();
     } catch (err) {
       assert.strictEqual(err.error.errorCode.number, 6001);
-      assert.strictEqual(err.error.errorMessage, "Conditional expression needs to evaluate to false before deposit accounts can be redeemed for underlying tokens");
+      assert.strictEqual(
+        err.error.errorMessage,
+        "Conditional expression needs to evaluate to false before deposit accounts can be redeemed for underlying tokens"
+      );
     }
 
     // this should pass, but because the user's conditional token account is empty, they should get 0 underlying tokens
-    await utils.redeemConditionalTokensForUnderlyingTokens(program, userConditionalTokenAccount, userUnderlyingTokenAccount, conditionalVault, proposal);
+    await utils.redeemConditionalTokensForUnderlyingTokens(
+      program,
+      userConditionalTokenAccount,
+      userUnderlyingTokenAccount,
+      conditionalVault,
+      proposal
+    );
 
     assert.equal(
       (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
@@ -373,124 +382,292 @@ describe("Conditional vault", () => {
       userUnderlyingTokenAccount,
       userConditionalTokenAccount
     );
-    it("Adversary cannot redeem deposit account or empty conditional token account for underlying tokens when condition evaluates to true.", async () => {
-      const proposalNumber = 38910;
-      const redeemableOnPass = false;
-  
-      const proposal = await accountInitUtils.initializeProposalAccount(
+  });
+
+  it("Adversary cannot mint conditional tokens without an equivalent amount of underlying tokens", async () => {
+    const proposalNumber = 38910;
+    const redeemableOnPass = false;
+
+    const proposal = await accountInitUtils.initializeProposalAccount(
+      program,
+      proposalNumber
+    );
+
+    const conditionalExpression =
+      await accountInitUtils.initializeConditionalExpression(
         program,
-        proposalNumber
-      );
-  
-      const conditionalExpression =
-        await accountInitUtils.initializeConditionalExpression(
-          program,
-          proposal,
-          redeemableOnPass
-        );
-  
-      const [underlyingTokenMint, underlyingTokenMintAuthority] =
-        await accountInitUtils.initializeUnderlyingTokenMint(provider);
-  
-      const [
-        conditionalVault,
-        conditionalTokenMint,
-        vaultUnderlyingTokenAccount,
-      ] = await accountInitUtils.initializeConditionalVault(
-        program,
-        conditionalExpression,
-        underlyingTokenMint
-      );
-  
-      const depositAccount = await accountInitUtils.initializeDepositAccount(
-        program,
-        conditionalVault
-      );
-  
-      const userUnderlyingTokenAccount = await token.createAccount(
-        provider.connection,
-        provider.wallet.payer,
-        underlyingTokenMint,
-        provider.wallet.publicKey
-      );
-  
-      const underlyingAmountToMint = 1000;
-      const conditionalAmountToMint = 400;
-  
-      await token.mintTo(
-        provider.connection,
-        provider.wallet.payer,
-        underlyingTokenMint,
-        userUnderlyingTokenAccount,
-        underlyingTokenMintAuthority,
-        underlyingAmountToMint
-      );
-  
-      const userConditionalTokenAccount = await token.createAccount(
-        provider.connection,
-        provider.wallet.payer,
-        conditionalTokenMint,
-        provider.wallet.publicKey
-      );
-  
-      await utils.mintConditionalTokens(
-        program,
-        conditionalVault,
-        conditionalAmountToMint,
-        depositAccount,
-        userUnderlyingTokenAccount,
-        userConditionalTokenAccount
+        proposal,
+        redeemableOnPass
       );
 
-      // main user sends away conditional tokens to Bob, who will try to redeem them even though expression evaluates to false
-      const bob = anchor.web3.Keypair.generate();
-      const bobConditionalTokenAccount = await token.createAccount(
-        provider.connection,
-        provider.wallet.payer,
-        conditionalTokenMint,
-        bob.publicKey,
-      );
-      const bobUnderlyingTokenAccount = await token.createAccount(
-        provider.connection,
-        provider.wallet.payer,
-        underlyingTokenMint,
-        bob.publicKey,
-      )
-      await token.transfer(
-        provider.connection,
-        provider.wallet.payer,
-        userConditionalTokenAccount,
-        conditionalTokenBurnAccount,
-        provider.wallet.publicKey,
-        conditionalAmountToMint
-      );
-  
+    const [underlyingTokenMint, underlyingTokenMintAuthority] =
+      await accountInitUtils.initializeUnderlyingTokenMint(provider);
+
+    const [
+      conditionalVault,
+      conditionalTokenMint,
+      vaultUnderlyingTokenAccount,
+    ] = await accountInitUtils.initializeConditionalVault(
+      program,
+      conditionalExpression,
+      underlyingTokenMint
+    );
+
+    const depositAccount = await accountInitUtils.initializeDepositAccount(
+      program,
+      conditionalVault
+    );
+
+    const userUnderlyingTokenAccount = await token.createAccount(
+      provider.connection,
+      provider.wallet.payer,
+      underlyingTokenMint,
+      provider.wallet.publicKey
+    );
+
+    const underlyingAmountToMint = 200;
+    const conditionalAmountToMint = 400;
+
+    await token.mintTo(
+      provider.connection,
+      provider.wallet.payer,
+      underlyingTokenMint,
+      userUnderlyingTokenAccount,
+      underlyingTokenMintAuthority,
+      underlyingAmountToMint
+    );
+
+    const userConditionalTokenAccount = await token.createAccount(
+      provider.connection,
+      provider.wallet.payer,
+      conditionalTokenMint,
+      provider.wallet.publicKey
+    );
+
+    try {
       await program.methods
-        .failProposal()
+        .mintConditionalTokens(new anchor.BN(conditionalAmountToMint))
         .accounts({
-          proposal,
+          conditionalVault,
+          tokenProgram: token.TOKEN_PROGRAM_ID,
+          conditionalTokenMint,
+          user: provider.wallet.publicKey,
+          depositAccount,
+          vaultUnderlyingTokenAccount,
+          userUnderlyingTokenAccount,
+          userConditionalTokenAccount,
         })
         .rpc();
-  
-      try {
-        await program.methods.redeemConditionalTokensForUnderlyingTokens()
-          .accounts({
-            user: bob.publicKey,
-            userConditionalTokenAccount: bobConditionalTokenAccount,
-            userUnderlyingTokenAccount: bobUnderlyingTokenAccount,
-            vaultUnderlyingTokenAccount,
-            conditionalVault,
-            proposal,
-            tokenProgram: token.TOKEN_PROGRAM_ID,
-            conditionalExpression,
-            conditionalTokenMint,
-          })
-          .rpc();
-        assert.fail();
-      } catch (err) {
-        assert.strictEqual(err.error.errorCode.number, 6000);
-        assert.strictEqual(err.error.errorMessage, "Conditional expression needs to evaluate to true before conditional tokens can be redeemed for underlying tokens");
-      }
-    });
+      assert.fail();
+    } catch (err) {
+      console.log(err.logs);
+      assert.ok(err.logs.contains("Program log: Error: insufficient funds"));
+    }
+  });
+
+  it("Adversary tries to mint conditional tokens with underlying tokens that don't match the vault's underlying tokens", async () => {
+    const proposalNumber = 38910;
+    const redeemableOnPass = false;
+
+    const proposal = await accountInitUtils.initializeProposalAccount(
+      program,
+      proposalNumber
+    );
+
+    const conditionalExpression =
+      await accountInitUtils.initializeConditionalExpression(
+        program,
+        proposal,
+        redeemableOnPass
+      );
+
+    const [underlyingTokenMint, underlyingTokenMintAuthority] =
+      await accountInitUtils.initializeUnderlyingTokenMint(provider);
+
+    const [
+      conditionalVault,
+      conditionalTokenMint,
+      vaultUnderlyingTokenAccount,
+    ] = await accountInitUtils.initializeConditionalVault(
+      program,
+      conditionalExpression,
+      underlyingTokenMint
+    );
+
+    const prankUnderlyingTokenMintAuthority = anchor.web3.Keypair.generate();
+    const prankUnderlyingTokenMint = await token.createMint(
+      provider.connection,
+      provider.wallet.payer,
+      prankUnderlyingTokenMintAuthority.publicKey,
+      null,
+      2
+    );
+    const prankUserUnderlyingTokenAccount = await token.createAccount(
+      provider.connection,
+      provider.wallet.payer,
+      prankUnderlyingTokenMint,
+      provider.wallet.publicKey
+    );
+    const prankVaultUnderlyingTokenAccount =
+      await token.getOrCreateAssociatedTokenAccount(
+        provider.connection,
+        provider.wallet.payer,
+        prankUnderlyingTokenMint,
+        conditionalVault,
+        true
+      );
+
+    const depositAccount = await accountInitUtils.initializeDepositAccount(
+      program,
+      conditionalVault
+    );
+
+    const underlyingAmountToMint = 1000;
+    const conditionalAmountToMint = 400;
+
+    await token.mintTo(
+      provider.connection,
+      provider.wallet.payer,
+      prankUnderlyingTokenMint,
+      prankUserUnderlyingTokenAccount,
+      prankUnderlyingTokenMintAuthority,
+      underlyingAmountToMint
+    );
+
+    const userConditionalTokenAccount = await token.createAccount(
+      provider.connection,
+      provider.wallet.payer,
+      conditionalTokenMint,
+      provider.wallet.publicKey
+    );
+
+    // a hack, maybe there's a better way to do this
+    let failedForRightReasons = true;
+    try {
+      await program.methods
+        .mintConditionalTokens(new anchor.BN(conditionalAmountToMint))
+        .accounts({
+          conditionalVault,
+          tokenProgram: token.TOKEN_PROGRAM_ID,
+          conditionalTokenMint,
+          user: provider.wallet.publicKey,
+          depositAccount,
+          vaultUnderlyingTokenAccount,
+          userUnderlyingTokenAccount: prankUserUnderlyingTokenAccount,
+          userConditionalTokenAccount,
+        })
+        .rpc();
+      failedForRightReasons = false;
+      assert.fail();
+    } catch (err) {
+      assert.ok(failedForRightReasons);
+    }
+  });
+
+  it("Adversary tries to redeem a deposit account multiple times", async () => {
+    const proposalNumber = 391031;
+    const redeemableOnPass = true;
+
+    const proposal = await accountInitUtils.initializeProposalAccount(
+      program,
+      proposalNumber
+    );
+
+    const conditionalExpression =
+      await accountInitUtils.initializeConditionalExpression(
+        program,
+        proposal,
+        redeemableOnPass
+      );
+
+    const [underlyingTokenMint, underlyingTokenMintAuthority] =
+      await accountInitUtils.initializeUnderlyingTokenMint(provider);
+
+    const [
+      conditionalVault,
+      conditionalTokenMint,
+      vaultUnderlyingTokenAccount,
+    ] = await accountInitUtils.initializeConditionalVault(
+      program,
+      conditionalExpression,
+      underlyingTokenMint
+    );
+
+    const depositAccount = await accountInitUtils.initializeDepositAccount(
+      program,
+      conditionalVault
+    );
+
+    const userUnderlyingTokenAccount = await token.createAccount(
+      provider.connection,
+      provider.wallet.payer,
+      underlyingTokenMint,
+      provider.wallet.publicKey
+    );
+
+    const underlyingAmountToMint = 1000;
+    const conditionalAmountToMint = 400;
+
+    await token.mintTo(
+      provider.connection,
+      provider.wallet.payer,
+      underlyingTokenMint,
+      userUnderlyingTokenAccount,
+      underlyingTokenMintAuthority,
+      underlyingAmountToMint
+    );
+
+    const userConditionalTokenAccount = await token.createAccount(
+      provider.connection,
+      provider.wallet.payer,
+      conditionalTokenMint,
+      provider.wallet.publicKey
+    );
+
+    await utils.mintConditionalTokens(
+      program,
+      conditionalVault,
+      conditionalAmountToMint,
+      depositAccount,
+      userUnderlyingTokenAccount,
+      userConditionalTokenAccount
+    );
+
+    await program.methods
+      .failProposal()
+      .accounts({
+        proposal,
+      })
+      .rpc();
+
+    // first one should be fine
+    await utils.redeemDepositAccountForUnderlyingTokens(
+      program,
+      depositAccount,
+      userUnderlyingTokenAccount,
+      conditionalVault,
+      proposal
+    );
+
+    assert.equal(
+      (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
+        .amount,
+      BigInt(underlyingAmountToMint)
+    );
+    
+    // second one should also go through, but shouldn't increase user's balance
+    await utils.redeemDepositAccountForUnderlyingTokens(
+      program,
+      depositAccount,
+      userUnderlyingTokenAccount,
+      conditionalVault,
+      proposal
+    );
+
+    assert.equal(
+      (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
+        .amount,
+      BigInt(underlyingAmountToMint)
+    );
   });
 });

--- a/tests/conditionalVault.ts
+++ b/tests/conditionalVault.ts
@@ -460,8 +460,7 @@ describe("Conditional vault", () => {
         .rpc();
       assert.fail();
     } catch (err) {
-      console.log(err.logs);
-      assert.ok(err.logs.contains("Program log: Error: insufficient funds"));
+      assert.ok(err.logs.includes("Program log: Error: insufficient funds"));
     }
   });
 

--- a/tests/conditionalVault.ts
+++ b/tests/conditionalVault.ts
@@ -3,6 +3,13 @@ import { Program } from "@project-serum/anchor";
 import { ConditionalVault } from "../target/types/conditional_vault";
 import { expect, assert } from "chai";
 import * as token from "@solana/spl-token";
+import * as accountInitUtils from "./accountInitializationUtils";
+import {
+  generateConditionalVaultPDAAddress,
+  generateDepositAccountPDAAddress,
+  generateConditionalExpressionPDAAddress,
+} from "./pdaGenerationUtils";
+import * as utils from "./utils";
 
 describe("Conditional vault", () => {
   const provider = anchor.AnchorProvider.env();
@@ -15,136 +22,30 @@ describe("Conditional vault", () => {
     const proposalNumber = 324;
     const redeemableOnPass = true;
 
-    const conditionalExpressionAccount =
-      await generateConditionalExpressionPDAAddress(
+    const conditionalExpression =
+      await accountInitUtils.initializeConditionalExpression(
         program,
         proposalNumber,
         redeemableOnPass
       );
 
-    await program.methods
-      .initializeConditionalExpression(
-        new anchor.BN(proposalNumber),
-        redeemableOnPass
-      )
-      .accounts({
-        conditionalExpression: conditionalExpressionAccount,
-        initializer: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc();
+    const [underlyingTokenMint, underlyingTokenMintAuthority] =
+      await accountInitUtils.initializeUnderlyingTokenMint(provider);
 
-    const storedConditionalExpression =
-      await program.account.conditionalExpression.fetch(
-        conditionalExpressionAccount
-      );
-
-    assert.ok(
-      storedConditionalExpression.proposalNumber.eq(
-        new anchor.BN(proposalNumber)
-      )
-    );
-    assert.equal(storedConditionalExpression.passOrFailFlag, redeemableOnPass);
-
-    console.log("Conditional expression successfully initialized.");
-
-    const underlyingTokenMintAuthority = anchor.web3.Keypair.generate();
-
-    const underlyingTokenMint = await token.createMint(
-      provider.connection,
-      provider.wallet.payer,
-      underlyingTokenMintAuthority.publicKey,
-      null,
-      2
-    );
-
-    const conditionalVaultAccount = await generateConditionalVaultPDAAddress(
+    const [
+      conditionalVault,
+      conditionalTokenMint,
+      vaultUnderlyingTokenAccount,
+    ] = await accountInitUtils.initializeConditionalVault(
       program,
-      conditionalExpressionAccount,
+      conditionalExpression,
       underlyingTokenMint
     );
 
-    const conditionalTokenMint = await token.createMint(
-      provider.connection,
-      provider.wallet.payer,
-      conditionalVaultAccount, // mint authority
-      null,
-      2
-    );
-
-    const vaultUnderlyingTokenAccount = (
-      await token.getOrCreateAssociatedTokenAccount(
-        provider.connection,
-        provider.wallet.payer,
-        underlyingTokenMint,
-        conditionalVaultAccount,
-        true
-      )
-    ).address;
-
-    await program.methods
-      .initializeConditionalVault()
-      .accounts({
-        conditionalVault: conditionalVaultAccount,
-        conditionalExpression: conditionalExpressionAccount,
-        underlyingTokenMint: underlyingTokenMint,
-        conditionalTokenMint: conditionalTokenMint,
-        vaultUnderlyingTokenAccount: vaultUnderlyingTokenAccount,
-        initializer: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc();
-
-    const storedConditionalVault = await program.account.conditionalVault.fetch(
-      conditionalVaultAccount
-    );
-
-    assert.ok(
-      storedConditionalVault.conditionalExpression.equals(
-        conditionalExpressionAccount
-      )
-    );
-    assert.ok(
-      storedConditionalVault.underlyingTokenAccount.equals(
-        vaultUnderlyingTokenAccount
-      )
-    );
-    assert.ok(
-      storedConditionalVault.underlyingTokenMint.equals(underlyingTokenMint)
-    );
-    assert.ok(
-      storedConditionalVault.conditionalTokenMint.equals(conditionalTokenMint)
-    );
-
-    console.log("Conditional vault successfully initialized.");
-
-    const depositAccount = await generateDepositAccountPDAAddress(
+    const depositAccount = await accountInitUtils.initializeDepositAccount(
       program,
-      conditionalVaultAccount,
-      provider.wallet.publicKey // the provider's wallet will be the one minting
+      conditionalVault
     );
-
-    await program.methods
-      .initializeDepositAccount()
-      .accounts({
-        conditionalVault: conditionalVaultAccount,
-        depositAccount,
-        depositor: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc();
-
-    let storedDepositAccount = await program.account.depositAccount.fetch(
-      depositAccount
-    );
-
-    assert.ok(
-      storedDepositAccount.conditionalVault.equals(conditionalVaultAccount)
-    );
-    assert.ok(storedDepositAccount.depositor.equals(provider.wallet.publicKey));
-    assert.ok(storedDepositAccount.depositedAmount.eq(new anchor.BN(0)));
-
-    console.log("Deposit account successfully initialized.");
 
     const userUnderlyingTokenAccount = await token.createAccount(
       provider.connection,
@@ -172,107 +73,34 @@ describe("Conditional vault", () => {
       provider.wallet.publicKey
     );
 
-    await program.methods
-      .mintConditionalTokens(new anchor.BN(conditionalAmountToMint))
-      .accounts({
-        conditionalVault: conditionalVaultAccount,
-        tokenProgram: token.TOKEN_PROGRAM_ID,
-        conditionalTokenMint,
-        user: provider.wallet.publicKey,
-        depositAccount,
-        vaultUnderlyingTokenAccount,
-        userUnderlyingTokenAccount,
-        userConditionalTokenAccount,
-      })
-      .rpc();
-
-    assert.equal(
-      (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
-        .amount,
-      underlyingAmountToMint - conditionalAmountToMint
-    );
-    assert.equal(
-      (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
-        .amount,
-      conditionalAmountToMint
-    );
-    assert.equal(
-      (await token.getAccount(provider.connection, userConditionalTokenAccount))
-        .amount,
-      conditionalAmountToMint
+    await utils.mintConditionalTokens(
+      program,
+      conditionalVault,
+      conditionalAmountToMint,
+      depositAccount,
+      userUnderlyingTokenAccount,
+      userConditionalTokenAccount
     );
 
-    storedDepositAccount = await program.account.depositAccount.fetch(
-      depositAccount
+    const proposal = await accountInitUtils.initializeProposalAccount(
+      program,
+      proposalNumber
     );
-
-    // these should remain the same
-    assert.ok(
-      storedDepositAccount.conditionalVault.equals(conditionalVaultAccount)
-    );
-    assert.ok(storedDepositAccount.depositor.equals(provider.wallet.publicKey));
-    // this should increase
-    assert.ok(
-      storedDepositAccount.depositedAmount.eq(
-        new anchor.BN(conditionalAmountToMint)
-      )
-    );
-
-    console.log(
-      "Conditional token account successfully credited after deposit."
-    );
-
-    const proposalAccount = anchor.web3.Keypair.generate();
-
-    await program.methods
-      .initializeProposal(new anchor.BN(proposalNumber))
-      .accounts({
-        proposal: proposalAccount.publicKey,
-        initializer: provider.wallet.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .signers([proposalAccount])
-      .rpc();
 
     await program.methods
       .passProposal()
       .accounts({
-        proposal: proposalAccount.publicKey,
+        proposal,
       })
       .rpc();
 
-    await program.methods
-      .redeemConditionalTokensForUnderlyingTokens()
-      .accounts({
-        user: provider.wallet.publicKey,
-        userConditionalTokenAccount,
-        userUnderlyingTokenAccount,
-        vaultUnderlyingTokenAccount,
-        conditionalVault: conditionalVaultAccount,
-        proposal: proposalAccount.publicKey,
-        tokenProgram: token.TOKEN_PROGRAM_ID,
-        conditionalExpression: conditionalExpressionAccount,
-        conditionalTokenMint,
-      })
-      .rpc();
-
-    assert.equal(
-      (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
-        .amount,
-      underlyingAmountToMint
+    await utils.redeemConditionalTokensForUnderlyingTokens(
+      program,
+      userConditionalTokenAccount,
+      userUnderlyingTokenAccount,
+      conditionalVault,
+      proposal
     );
-    assert.equal(
-      (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
-        .amount,
-      0
-    );
-    assert.equal(
-      (await token.getAccount(provider.connection, userConditionalTokenAccount))
-        .amount,
-      0
-    );
-
-    console.log("Underlying tokens successfully redeemed after proposal pass");
   });
 
   it("Flow #2 - user mints, condition evaluates to false, user redeems deposit account", async () => {
@@ -544,54 +372,3 @@ describe("Conditional vault", () => {
     console.log("Underlying tokens successfully redeemed after proposal pass");
   });
 });
-
-async function generateConditionalExpressionPDAAddress(
-  program: Program,
-  proposalNumber: number,
-  redeemableOnPass: boolean
-) {
-  const [conditionalExpressionAcc] =
-    await anchor.web3.PublicKey.findProgramAddress(
-      [
-        anchor.utils.bytes.utf8.encode("conditional-expression"),
-        new anchor.BN(proposalNumber).toBuffer("be", 8),
-        Buffer.from([redeemableOnPass]),
-      ],
-      program.programId
-    );
-
-  return conditionalExpressionAcc;
-}
-
-async function generateConditionalVaultPDAAddress(
-  program: Program,
-  conditionalExpressionAddress: anchor.web3.PublicKey,
-  mint: anchor.web3.PublicKey
-) {
-  const [conditionalVaultAcc] = await anchor.web3.PublicKey.findProgramAddress(
-    [
-      anchor.utils.bytes.utf8.encode("conditional-vault"),
-      conditionalExpressionAddress.toBuffer(),
-      mint.toBuffer(),
-    ],
-    program.programId
-  );
-  return conditionalVaultAcc;
-}
-
-async function generateDepositAccountPDAAddress(
-  program: Program,
-  conditionalVault: anchor.web3.PublicKey,
-  user: anchor.web3.PublicKey
-) {
-  const [depositAcc] = await anchor.web3.PublicKey.findProgramAddress(
-    [
-      anchor.utils.bytes.utf8.encode("deposit-account"),
-      conditionalVault.toBuffer(),
-      user.toBuffer(),
-    ],
-    program.programId
-  );
-
-  return depositAcc;
-}

--- a/tests/pdaGenerationUtils.ts
+++ b/tests/pdaGenerationUtils.ts
@@ -1,0 +1,57 @@
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+
+const BIG_ENDIAN = "be";
+
+export async function generateConditionalExpressionPDAAddress(
+  program: Program,
+  proposalNumber: number,
+  redeemableOnPass: boolean
+) {
+  const [conditionalExpressionPDAAddress] =
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        anchor.utils.bytes.utf8.encode("conditional-expression"),
+        new anchor.BN(proposalNumber).toBuffer(BIG_ENDIAN, 8),
+        Buffer.from([redeemableOnPass]),
+      ],
+      program.programId
+    );
+
+  return conditionalExpressionPDAAddress;
+}
+
+export async function generateConditionalVaultPDAAddress(
+  program: Program,
+  conditionalExpressionAddress: anchor.web3.PublicKey,
+  mint: anchor.web3.PublicKey
+) {
+  const [conditionalVaultPDAAddress] =
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        anchor.utils.bytes.utf8.encode("conditional-vault"),
+        conditionalExpressionAddress.toBuffer(),
+        mint.toBuffer(),
+      ],
+      program.programId
+    );
+  return conditionalVaultPDAAddress;
+}
+
+export async function generateDepositAccountPDAAddress(
+  program: Program,
+  conditionalVault: anchor.web3.PublicKey,
+  user: anchor.web3.PublicKey
+) {
+  const [depositAccountPDAAddress] =
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        anchor.utils.bytes.utf8.encode("deposit-account"),
+        conditionalVault.toBuffer(),
+        user.toBuffer(),
+      ],
+      program.programId
+    );
+
+  return depositAccountPDAAddress;
+}

--- a/tests/pdaGenerationUtils.ts
+++ b/tests/pdaGenerationUtils.ts
@@ -5,14 +5,14 @@ const BIG_ENDIAN = "be";
 
 export async function generateConditionalExpressionPDAAddress(
   program: Program,
-  proposalNumber: number,
+  proposal: anchor.web3.PublicKey,
   redeemableOnPass: boolean
 ) {
   const [conditionalExpressionPDAAddress] =
     await anchor.web3.PublicKey.findProgramAddress(
       [
         anchor.utils.bytes.utf8.encode("conditional-expression"),
-        new anchor.BN(proposalNumber).toBuffer(BIG_ENDIAN, 8),
+        proposal.toBuffer(),
         Buffer.from([redeemableOnPass]),
       ],
       program.programId

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -102,11 +102,14 @@ export const redeemConditionalTokensForUnderlyingTokens = async (
     storedConditionalVault.underlyingTokenAccount;
   const conditionalExpression = storedConditionalVault.conditionalExpression;
 
-  const preMintUserConditionalBalance = (
+  const preRedeemUserConditionalBalance = (
     await token.getAccount(provider.connection, userConditionalTokenAccount)
   ).amount;
-  const preMintUserUnderlyingBalance = (
+  const preRedeemUserUnderlyingBalance = (
     await token.getAccount(provider.connection, userUnderlyingTokenAccount)
+  ).amount;
+  const preRedeemVaultUnderlyingBalance = (
+    await token.getAccount(provider.connection, vaultUnderlyingTokenAccount)
   ).amount;
 
   await program.methods
@@ -127,12 +130,12 @@ export const redeemConditionalTokensForUnderlyingTokens = async (
   assert.equal(
     (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
       .amount,
-    preMintUserConditionalBalance + preMintUserUnderlyingBalance
+    preRedeemUserConditionalBalance + preRedeemUserUnderlyingBalance
   );
   assert.equal(
     (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
       .amount,
-    BigInt(0)
+    preRedeemVaultUnderlyingBalance - preRedeemUserConditionalBalance
   );
   assert.equal(
     (await token.getAccount(provider.connection, userConditionalTokenAccount))

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,144 @@
+import * as anchor from "@project-serum/anchor";
+import { expect, assert } from "chai";
+import * as token from "@solana/spl-token";
+import { ConditionalVault } from "../target/types/conditional_vault";
+
+export const mintConditionalTokens = async (
+  program: anchor.Program<ConditionalVault>,
+  conditionalVault: anchor.web3.PublicKey,
+  amount: number,
+  depositAccount: anchor.web3.PublicKey,
+  userUnderlyingTokenAccount: anchor.web3.PublicKey,
+  userConditionalTokenAccount: anchor.web3.PublicKey
+) => {
+  const provider = program.provider;
+  const storedConditionalVault = await program.account.conditionalVault.fetch(
+    conditionalVault
+  );
+  const conditionalTokenMint = storedConditionalVault.conditionalTokenMint;
+  const vaultUnderlyingTokenAccount =
+    storedConditionalVault.underlyingTokenAccount;
+
+  const preMintUserUnderlyingBalance = (
+    await token.getAccount(provider.connection, userUnderlyingTokenAccount)
+  ).amount;
+  const preMintVaultUnderlyingBalance = (
+    await token.getAccount(provider.connection, vaultUnderlyingTokenAccount)
+  ).amount;
+  const preMintUserConditionalBalance = (
+    await token.getAccount(provider.connection, userConditionalTokenAccount)
+  ).amount;
+
+  let storedDepositAccount = await program.account.depositAccount.fetch(
+    depositAccount
+  );
+  const preMintDepositAmount = storedDepositAccount.depositedAmount;
+
+  await program.methods
+    .mintConditionalTokens(new anchor.BN(amount))
+    .accounts({
+      conditionalVault,
+      tokenProgram: token.TOKEN_PROGRAM_ID,
+      conditionalTokenMint,
+      user: provider.wallet.publicKey,
+      depositAccount,
+      vaultUnderlyingTokenAccount,
+      userUnderlyingTokenAccount,
+      userConditionalTokenAccount,
+    })
+    .rpc();
+
+  assert.equal(
+    (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
+      .amount,
+    preMintUserUnderlyingBalance - BigInt(amount)
+  );
+
+  assert.equal(
+    (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
+      .amount,
+    preMintVaultUnderlyingBalance + BigInt(amount)
+  );
+  assert.equal(
+    (await token.getAccount(provider.connection, userConditionalTokenAccount))
+      .amount,
+    preMintUserConditionalBalance + BigInt(amount)
+  );
+
+  storedDepositAccount = await program.account.depositAccount.fetch(
+    depositAccount
+  );
+
+  // these should remain the same
+  assert.ok(storedDepositAccount.conditionalVault.equals(conditionalVault));
+  assert.ok(storedDepositAccount.depositor.equals(provider.wallet.publicKey));
+  // this should increase
+  assert.ok(
+    storedDepositAccount.depositedAmount.eq(
+      preMintDepositAmount.add(new anchor.BN(amount))
+    )
+  );
+
+  console.log("Conditional token account successfully credited after deposit.");
+};
+
+type Program = anchor.Program<ConditionalVault>;
+type PublicKey = anchor.web3.PublicKey;
+
+export const redeemConditionalTokensForUnderlyingTokens = async (
+  program: Program,
+  userConditionalTokenAccount: PublicKey,
+  userUnderlyingTokenAccount: PublicKey,
+  conditionalVault: PublicKey,
+  proposal: PublicKey
+) => {
+  const provider = program.provider;
+
+  const storedConditionalVault = await program.account.conditionalVault.fetch(
+    conditionalVault
+  );
+  const conditionalTokenMint = storedConditionalVault.conditionalTokenMint;
+  const vaultUnderlyingTokenAccount =
+    storedConditionalVault.underlyingTokenAccount;
+  const conditionalExpression = storedConditionalVault.conditionalExpression;
+
+  const preMintUserConditionalBalance = (
+    await token.getAccount(provider.connection, userConditionalTokenAccount)
+  ).amount;
+  const preMintUserUnderlyingBalance = (
+    await token.getAccount(provider.connection, userUnderlyingTokenAccount)
+  ).amount;
+
+  await program.methods
+    .redeemConditionalTokensForUnderlyingTokens()
+    .accounts({
+      user: provider.wallet.publicKey,
+      userConditionalTokenAccount,
+      userUnderlyingTokenAccount,
+      vaultUnderlyingTokenAccount,
+      conditionalVault,
+      proposal,
+      tokenProgram: token.TOKEN_PROGRAM_ID,
+      conditionalExpression,
+      conditionalTokenMint,
+    })
+    .rpc();
+
+  assert.equal(
+    (await token.getAccount(provider.connection, userUnderlyingTokenAccount))
+      .amount,
+    preMintUserConditionalBalance + preMintUserUnderlyingBalance
+  );
+  assert.equal(
+    (await token.getAccount(provider.connection, vaultUnderlyingTokenAccount))
+      .amount,
+    BigInt(0)
+  );
+  assert.equal(
+    (await token.getAccount(provider.connection, userConditionalTokenAccount))
+      .amount,
+    BigInt(0)
+  );
+
+  console.log("Underlying tokens successfully redeemed after proposal pass");
+};

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,13 +3,16 @@ import { expect, assert } from "chai";
 import * as token from "@solana/spl-token";
 import { ConditionalVault } from "../target/types/conditional_vault";
 
+type Program = anchor.Program<ConditionalVault>;
+type PublicKey = anchor.web3.PublicKey;
+
 export const mintConditionalTokens = async (
-  program: anchor.Program<ConditionalVault>,
-  conditionalVault: anchor.web3.PublicKey,
+  program: Program,
+  conditionalVault: PublicKey,
   amount: number,
-  depositAccount: anchor.web3.PublicKey,
-  userUnderlyingTokenAccount: anchor.web3.PublicKey,
-  userConditionalTokenAccount: anchor.web3.PublicKey
+  depositAccount: PublicKey,
+  userUnderlyingTokenAccount: PublicKey,
+  userConditionalTokenAccount: PublicKey
 ) => {
   const provider = program.provider;
   const storedConditionalVault = await program.account.conditionalVault.fetch(
@@ -81,9 +84,6 @@ export const mintConditionalTokens = async (
 
   console.log("Conditional token account successfully credited after deposit.");
 };
-
-type Program = anchor.Program<ConditionalVault>;
-type PublicKey = anchor.web3.PublicKey;
 
 export const redeemConditionalTokensForUnderlyingTokens = async (
   program: Program,


### PR DESCRIPTION
- add check during redemption time that either
  - the user is trying to redeem conditional tokens for underlying tokens && the conditional expression has evaluated to true
  - the user is trying to redeem a deposit account for underlying tokens && the expression has evaluated to false
- test above checks and other cases in #6 